### PR TITLE
Annotation based shardKey mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public class Main {
         record User(@ShardKey String id, String name) {
         }
         // this is your strategy
-        HashingShardingStrategy<User> hashingStrategy = new HashingShardingStrategy<>(userIdExtractor);
+        HashingShardingStrategy<User> hashingStrategy = new HashingShardingStrategy<>();
         // yaml shardProvider (read down below to know more about this)
         ShardUrlProvider shardUrlProvider = new YamlShardUrlProvider("config.yaml");
         // redis shardProvider (read down below to know more about this)

--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ Each shard can have internal partitions based on date or whatever makes sense fo
 ### Example
 
 ```java
+import me.devcoffee.annotations.ShardKey;
+
 public class Main {
     public static void main(String[] args) throws Exception {
         // this is your data schema (POJO)
-        record User(String id, String name) {}
-        // this is your key extractor to submit to the hashing method
-        Function<User, String> userIdExtractor = user -> user.id();
+        // @ShardKey is your DAO's sharding key, use this to set and get data
+        record User(@ShardKey String id, String name) {
+        }
         // this is your strategy
         HashingShardingStrategy<User> hashingStrategy = new HashingShardingStrategy<>(userIdExtractor);
         // yaml shardProvider (read down below to know more about this)
@@ -71,11 +73,10 @@ public class Main {
         int shardCount = 16;
 
         ShardingConfig<User> hashingConfig = new ShardingConfig.Builder<User>().withShardCount(shardCount).withShardingStrategy(hashingStrategy).withShardUrlProvider(redisUrlProvider).build();
-        
+
         UUID uuid = UUID.randomUUID();
         User newUser = new User(uuid.toString(), "Prajwal P");
-
-
+        
         int shardId = hashingConfig.determineShard(newUser);
         String shardUrl = hashingConfig.getShardUrl(shardId);
         System.out.println("User will be inserted into shard " + shardId + " if we use HashBased Strategy with endpoint " + shardUrl);

--- a/src/main/java/me/devcoffee/Main.java
+++ b/src/main/java/me/devcoffee/Main.java
@@ -1,38 +1,33 @@
 package me.devcoffee;
 
-import me.devcoffee.config.RedisShardUrlProvider;
+import me.devcoffee.annotations.ShardKey;
 import me.devcoffee.config.ShardUrlProvider;
 import me.devcoffee.config.YamlShardUrlProvider;
 import me.devcoffee.config.ShardingConfig;
 import me.devcoffee.strategies.HashingShardingStrategy;
-import redis.clients.jedis.Jedis;
 
 import java.util.UUID;
-import java.util.function.Function;
 
 // following is an example of how to use this package
 public class Main {
     public static void main(String[] args) throws Exception {
 
-        record User(String id, String name) {}
-        Function<User, String> userIdExtractor = user -> user.id();
-        HashingShardingStrategy<User> hashingStrategy = new HashingShardingStrategy<>(userIdExtractor);
+        record User(@ShardKey String id, String name) {}
+        HashingShardingStrategy<User> hashingStrategy = new HashingShardingStrategy<>();
         ShardUrlProvider shardUrlProvider = new YamlShardUrlProvider("config.yaml");
-        ShardUrlProvider redisUrlProvider = new RedisShardUrlProvider(new Jedis("localhost", 6379), "config.yaml");
         int shardCount = 16;
 
-        ShardingConfig<User> hashingConfig = new ShardingConfig.Builder<User>().withShardCount(shardCount).withShardingStrategy(hashingStrategy).withShardUrlProvider(redisUrlProvider).build();
+        ShardingConfig<User> hashingConfig = new ShardingConfig.Builder<User>().withShardCount(shardCount).withShardingStrategy(hashingStrategy).withShardUrlProvider(shardUrlProvider).build();
         UUID uuid = UUID.randomUUID();
         User newUser = new User(uuid.toString(), "Prajwal P");
 
-
         int shardId = hashingConfig.determineShard(newUser);
         String shardUrl = hashingConfig.getShardUrl(shardId);
+
         System.out.println("User will be inserted into shard " + shardId + " if we use HashBased Strategy with endpoint " + shardUrl);
         // if you change the shard count, all data must be rehashed to map to the new shards, very expensive, so plan your capacity very carefully
         hashingConfig.updateShardCount(6);
         shardId = hashingConfig.determineShard(newUser);
-        shardUrl = hashingConfig.getShardUrl(shardId);
         System.out.println("User will be inserted into shard " + shardId + " if we use HashBased Strategy after updating the shardCount with endpoint " + shardUrl);
     }
 }

--- a/src/main/java/me/devcoffee/annotations/ShardKey.java
+++ b/src/main/java/me/devcoffee/annotations/ShardKey.java
@@ -1,0 +1,11 @@
+package me.devcoffee.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ShardKey {
+}

--- a/src/main/java/me/devcoffee/strategies/HashingShardingStrategy.java
+++ b/src/main/java/me/devcoffee/strategies/HashingShardingStrategy.java
@@ -1,25 +1,43 @@
 package me.devcoffee.strategies;
 
 import com.google.common.hash.Hashing;
+import me.devcoffee.annotations.ShardKey;
+
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Function;
 
 public class HashingShardingStrategy<T> implements ShardingStrategy<T> {
-    private final Function<T, String> keyExtractor;
-
-    public HashingShardingStrategy(Function<T, String> keyExtractor) {
-        this.keyExtractor = keyExtractor;
-    }
 
     @Override
     public int getShardId(T entity, Integer shardCount) {
-        String key = keyExtractor.apply(entity);
-        // Compute 128-bit hash and then convert it to a 32-bit integer for modulus
+        String key = extractShardKey(entity);
         int hash = Hashing.murmur3_128().hashString(key, StandardCharsets.UTF_8).asInt();
-        // Ensure a positive value before modulus
         hash = Math.abs(hash);
-        // Make sure that hash is less than shardCount and always return 1 if the hash %  shardCount is 0
         return Math.max(1, hash % shardCount);
     }
-}
 
+    private String extractShardKey(T entity) {
+        String shardKeyValue = null;
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(ShardKey.class)) {
+                // there should be only one shardKey in a DAO
+                if (shardKeyValue != null) {
+                    throw new IllegalArgumentException("Found multiple fields annotated with @ShardKey in class " + entity.getClass().getName());
+                }
+                field.setAccessible(true);
+                try {
+                    Object value = field.get(entity);
+                    if (value != null) {
+                        shardKeyValue = value.toString();
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to access shard key field", e);
+                }
+            }
+        }
+        if (shardKeyValue == null) {
+            throw new IllegalArgumentException("No field annotated with @ShardKey found in class " + entity.getClass().getName());
+        }
+        return shardKeyValue;
+    }
+}

--- a/src/main/java/me/devcoffee/strategies/HashingShardingStrategy.java
+++ b/src/main/java/me/devcoffee/strategies/HashingShardingStrategy.java
@@ -1,9 +1,6 @@
 package me.devcoffee.strategies;
 
 import com.google.common.hash.Hashing;
-import me.devcoffee.annotations.ShardKey;
-
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
 public class HashingShardingStrategy<T> implements ShardingStrategy<T> {
@@ -12,32 +9,9 @@ public class HashingShardingStrategy<T> implements ShardingStrategy<T> {
     public int getShardId(T entity, Integer shardCount) {
         String key = extractShardKey(entity);
         int hash = Hashing.murmur3_128().hashString(key, StandardCharsets.UTF_8).asInt();
+        // make hash positive
         hash = Math.abs(hash);
+        // don't return 0
         return Math.max(1, hash % shardCount);
-    }
-
-    private String extractShardKey(T entity) {
-        String shardKeyValue = null;
-        for (Field field : entity.getClass().getDeclaredFields()) {
-            if (field.isAnnotationPresent(ShardKey.class)) {
-                // there should be only one shardKey in a DAO
-                if (shardKeyValue != null) {
-                    throw new IllegalArgumentException("Found multiple fields annotated with @ShardKey in class " + entity.getClass().getName());
-                }
-                field.setAccessible(true);
-                try {
-                    Object value = field.get(entity);
-                    if (value != null) {
-                        shardKeyValue = value.toString();
-                    }
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException("Failed to access shard key field", e);
-                }
-            }
-        }
-        if (shardKeyValue == null) {
-            throw new IllegalArgumentException("No field annotated with @ShardKey found in class " + entity.getClass().getName());
-        }
-        return shardKeyValue;
     }
 }

--- a/src/main/java/me/devcoffee/strategies/ShardingStrategy.java
+++ b/src/main/java/me/devcoffee/strategies/ShardingStrategy.java
@@ -1,6 +1,35 @@
 package me.devcoffee.strategies;
 
+import me.devcoffee.annotations.ShardKey;
+
+import java.lang.reflect.Field;
+
 // All strategies must implement this interface
 public interface ShardingStrategy<T> {
     int getShardId(T entity, Integer shardCount);
+
+    default String extractShardKey(T entity) {
+        String shardKeyValue = null;
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(ShardKey.class)) {
+                // there should be only one shardKey in a DAO
+                if (shardKeyValue != null) {
+                    throw new IllegalArgumentException("Found multiple fields annotated with @ShardKey in class " + entity.getClass().getName());
+                }
+                field.setAccessible(true);
+                try {
+                    Object value = field.get(entity);
+                    if (value != null) {
+                        shardKeyValue = value.toString();
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to access shard key field", e);
+                }
+            }
+        }
+        if (shardKeyValue == null) {
+            throw new IllegalArgumentException("No field annotated with @ShardKey found in class " + entity.getClass().getName());
+        }
+        return shardKeyValue;
+    }
 }


### PR DESCRIPTION
This pull request introduces a new annotation-based approach for identifying sharding keys in entities, replacing the previous function-based key extraction mechanism. The changes simplify the configuration process for sharding strategies and improve code readability. Key updates include the introduction of the `@ShardKey` annotation, modifications to the `HashingShardingStrategy` and `ShardingStrategy` classes, and updates to the example usage in the `README.md` and `Main.java`.

### Annotation-based Sharding Key Extraction:
* Added a new `@ShardKey` annotation to mark fields in entity classes as sharding keys. This replaces the need for manually providing a key extraction function. (`src/main/java/me/devcoffee/annotations/ShardKey.java`)
* Updated the `ShardingStrategy` interface to include a `extractShardKey` default method that uses reflection to extract the value of the `@ShardKey`-annotated field. This ensures only one `@ShardKey` is allowed per entity and throws an error if no or multiple annotations are found. (`src/main/java/me/devcoffee/strategies/ShardingStrategy.java`)

These changes make the library easier to use by reducing boilerplate code and enforcing a standardized way to define and extract sharding keys.