### PR TITLE
fix YamlShardUrlProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.devcoffee</groupId>
     <artifactId>shard</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/me/devcoffee/Main.java
+++ b/src/main/java/me/devcoffee/Main.java
@@ -26,8 +26,11 @@ public class Main {
 
         System.out.println("User will be inserted into shard " + shardId + " if we use HashBased Strategy with endpoint " + shardUrl);
         // if you change the shard count, all data must be rehashed to map to the new shards, very expensive, so plan your capacity very carefully
+        // TODO, implement a way to rehash the data
+        // ? what should we do if a shard goes down?, we can blacklist it but ofc it will affect the count, need to think a bit here
         hashingConfig.updateShardCount(6);
         shardId = hashingConfig.determineShard(newUser);
+        shardUrl = hashingConfig.getShardUrl(shardId);
         System.out.println("User will be inserted into shard " + shardId + " if we use HashBased Strategy after updating the shardCount with endpoint " + shardUrl);
     }
 }

--- a/src/main/java/me/devcoffee/config/YamlShardUrlProvider.java
+++ b/src/main/java/me/devcoffee/config/YamlShardUrlProvider.java
@@ -11,45 +11,58 @@ import java.util.regex.Pattern;
 
 public class YamlShardUrlProvider implements ShardUrlProvider {
 
-    private static final Pattern RANGE_PATTERN = Pattern.compile("\\{(\\d+)\\.\\.(\\d+)}");
-    private final Map<String, String> expandedShardMap;
+    private static final Pattern SHARD_RANGE_PATTERN = Pattern.compile("\\{(\\d+)\\.\\.(\\d+)}");
+    private final Map<Integer, String> originalShardIdToUrlMap;
 
     public YamlShardUrlProvider(String filePath) {
+        this.originalShardIdToUrlMap = loadShardMappings(filePath);
+    }
+
+    @Override
+    public String apply(Integer shardId) {
+        String shardUrl = originalShardIdToUrlMap.get(shardId);
+        if (shardUrl == null) {
+            throw new IllegalArgumentException("No mapping found for shard ID: " + shardId);
+        }
+        return shardUrl;
+    }
+
+
+    private Map<Integer, String> loadShardMappings(String filePath) {
         Yaml yaml = new Yaml(new Constructor(ShardConfigYaml.class, new LoaderOptions()));
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream(filePath);
         if (inputStream == null) {
             throw new RuntimeException("YAML file not found: " + filePath);
         }
+
         ShardConfigYaml configYaml = yaml.load(inputStream);
-        this.expandedShardMap = expandShardMap(configYaml);
+        return expandShardMappings(configYaml.getShards());
     }
 
-    @Override
-    public String apply(Integer shardId) {
-        Optional<String> matchedKey = expandedShardMap.keySet().stream()
-                .filter(k -> k.matches(".*?(\\d+)$") &&
-                        Integer.parseInt(k.replaceAll(".*?(\\d+)$", "$1")) == shardId)
-                .findFirst();
+    private Map<Integer, String> expandShardMappings(Map<String, String> shardConfig) {
+        Map<Integer, String> expandedMap = new HashMap<>();
 
-        return matchedKey.map(key -> expandedShardMap.get(key) + shardId)
-                .orElseThrow(() -> new IllegalArgumentException("No mapping found for shard ID: " + shardId));
-    }
+        for (Map.Entry<String, String> entry : shardConfig.entrySet()) {
+            String shardKey = entry.getKey();
+            String shardUrl = entry.getValue();
 
-    private Map<String, String> expandShardMap(ShardConfigYaml configYaml) {
-        Map<String, String> expanded = new HashMap<>();
-        for (Map.Entry<String, String> entry : configYaml.getShards().entrySet()) {
-            Matcher matcher = RANGE_PATTERN.matcher(entry.getKey());
+            Matcher matcher = SHARD_RANGE_PATTERN.matcher(shardKey);
             if (matcher.find()) {
                 int start = Integer.parseInt(matcher.group(1));
                 int end = Integer.parseInt(matcher.group(2));
+
+                if (start > end) {
+                    throw new IllegalArgumentException("Invalid shard range: " + shardKey);
+                }
+
                 for (int i = start; i <= end; i++) {
-                    String expandedKey = entry.getKey().replace(matcher.group(0), String.valueOf(i));
-                    expanded.put(expandedKey, entry.getValue());
+                    expandedMap.put(i, shardUrl);
                 }
             } else {
-                expanded.put(entry.getKey(), entry.getValue());
+                throw new IllegalArgumentException("Invalid shard key format: " + shardKey);
             }
         }
-        return expanded;
+
+        return expandedMap;
     }
 }


### PR DESCRIPTION
### Version Update:
* Updated the project version in `pom.xml` from `1.0.1-SNAPSHOT` to `1.3.0-SNAPSHOT`, indicating new features and improvements.

### Enhancements to Shard URL Mapping:
* Refactored the `YamlShardUrlProvider` class:
  - Replaced `expandedShardMap` with `originalShardIdToUrlMap` for a more direct mapping of shard IDs to URLs.
  - Introduced a new `loadShardMappings` method to load shard configurations from a YAML file and validate shard ranges.
  - Improved error handling by throwing exceptions for invalid shard keys or ranges.